### PR TITLE
新增token 验证机制

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -2,6 +2,7 @@ use common::cookie_manager::CookieManager;
 use common::http_utils::request_get;
 use common::login::QrCodeLoginStatus;
 use common::ticket::*;
+use common::token_manager;
 use rand::{Rng, thread_rng};
 use reqwest::Client;
 use serde_json;
@@ -257,6 +258,26 @@ pub async fn get_ticket_token(
     ticket_id: &str,
     count: i16,
 ) -> Result<String, TokenRiskParam> {
+    // 获取ctoken和ptoken
+    let (ctoken, ptoken) = match token_manager::get_tokens(cookie_manager.clone(), project_id).await {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            log::error!("获取token失败：{}", e);
+            return Err(TokenRiskParam {
+                code: 999,
+                message: format!("获取token失败：{}", e),
+                mid: None,
+                decision_type: None,
+                buvid: None,
+                ip: None,
+                scene: None,
+                ua: None,
+                v_voucher: None,
+                risk_param: None,
+            });
+        }
+    };
+
     let params = serde_json::json!({
         "project_id": project_id,
         "screen_id": screen_id,
@@ -266,6 +287,8 @@ pub async fn get_ticket_token(
         "token": "",
         "requestSource": "neul-next",
         "newRisk": "true",
+        "ctoken": ctoken,
+        "ptoken": ptoken,
     });
 
     let url = format!(
@@ -468,6 +491,14 @@ pub async fn create_order(
     fast_mode: bool,
     screen_size: Option<(u32, u32)>, // 可选参数：(宽度,高度)
 ) -> Result<Value, i32> {
+    // 获取ctoken和ptoken
+    let (ctoken, ptoken) = match token_manager::get_tokens(cookie_manager.clone(), project_id).await {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            log::error!("获取token失败：{}", e);
+            return Err(999);
+        }
+    };
     let url = format!(
         "https://show.bilibili.com/api/ticket/order/createV2?project_id={}",
         project_id
@@ -537,6 +568,8 @@ pub async fn create_order(
                 "count": count,
                 "timestamp": timestamp,
                 "order_type": 1,
+                "ctoken": ctoken,
+                "ptoken": ptoken,
             });
             data
         }
@@ -555,6 +588,8 @@ pub async fn create_order(
                 "count": count,
                 "timestamp": timestamp,
                 "order_type": 1,
+                "ctoken": ctoken,
+                "ptoken": ptoken,
             });
             data
         }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 reqwest = { version="0.11.22", features=["json", "blocking", "cookies"]}
+anyhow = "1.0"
 
 base64 = "0.21"
 aes = "0.7.5"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod record_log;
 pub mod show_orderlist;
 pub mod taskmanager;
 pub mod ticket;
+pub mod token_manager;
 pub mod utility;
 pub mod utils;
 

--- a/common/src/token_manager.rs
+++ b/common/src/token_manager.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE, COOKIE, REFERER, USER_AGENT};
+use serde_json::Value;
+use anyhow::{Result, anyhow};
+
+use crate::cookie_manager::CookieManager;
+
+/// 获取ctoken和ptoken
+/// 
+/// # 参数
+/// 
+/// * `cookie_manager` - Cookie管理器
+/// * `project_id` - 项目ID
+/// 
+/// # 返回值
+/// 
+/// 返回一个包含ctoken和ptoken的元组
+pub async fn get_tokens(cookie_manager: Arc<CookieManager>, project_id: &str) -> Result<(String, String)> {
+    log::info!("开始获取ctoken和ptoken");
+    
+    let client = reqwest::Client::new();
+    
+    // 构建请求头
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"));
+    headers.insert(REFERER, HeaderValue::from_str(&format!("https://show.bilibili.com/platform/detail.html?id={}", project_id))?);
+    
+    // 添加Cookie
+    let cookie_str = cookie_manager.get_all_cookies();
+    headers.insert(COOKIE, HeaderValue::from_str(&cookie_str)?);
+    
+    // 构建请求URL
+    let url = format!("https://show.bilibili.com/api/ticket/project/get?id={}", project_id);
+    
+    // 发送请求
+    let response = client.get(&url)
+        .headers(headers)
+        .send()
+        .await?;
+    
+    // 检查响应状态
+    if !response.status().is_success() {
+        return Err(anyhow!("获取token失败，HTTP状态码: {}", response.status()));
+    }
+    
+    // 解析响应
+    let response_text = response.text().await?;
+    let response_json: Value = serde_json::from_str(&response_text)?;
+    
+    // 检查响应码
+    let code = response_json["code"].as_i64().unwrap_or(-1);
+    if code != 0 {
+        let message = response_json["message"].as_str().unwrap_or("未知错误");
+        return Err(anyhow!("获取token失败，错误码: {}，错误信息: {}", code, message));
+    }
+    
+    // 提取ctoken和ptoken
+    let ctoken = response_json["data"]["ctoken"].as_str()
+        .ok_or_else(|| anyhow!("响应中没有ctoken"))?
+        .to_string();
+    
+    let ptoken = response_json["data"]["ptoken"].as_str()
+        .ok_or_else(|| anyhow!("响应中没有ptoken"))?
+        .to_string();
+    
+    log::info!("成功获取ctoken和ptoken");
+    
+    Ok((ctoken, ptoken))
+}
+
+/// 刷新token
+/// 
+/// 当token过期时，可以调用此函数刷新token
+/// 
+/// # 参数
+/// 
+/// * `cookie_manager` - Cookie管理器
+/// * `project_id` - 项目ID
+/// 
+/// # 返回值
+/// 
+/// 返回一个包含新的ctoken和ptoken的元组
+pub async fn refresh_tokens(cookie_manager: Arc<CookieManager>, project_id: &str) -> Result<(String, String)> {
+    log::info!("开始刷新ctoken和ptoken");
+    
+    // 实现刷新token的逻辑，这里简单地调用get_tokens
+    get_tokens(cookie_manager, project_id).await
+}


### PR DESCRIPTION
1. 在获取票务 token 时使用 ctoken 和 ptoken 进行验证
2. 在创建订单时使用 ctoken 和 ptoken 进行验证
3. 提高购票请求的合法性，减少被系统拦截的可能性
这些修改将显著提高购票成功率，特别是在高峰期和热门票务抢购时